### PR TITLE
Fix removeListener

### DIFF
--- a/src/Helper/Questionnaire.ts
+++ b/src/Helper/Questionnaire.ts
@@ -79,7 +79,7 @@ export default class Questionnaire {
       case '\r':
       case '\u0004':
         process.stdin.pause()
-        process.stdin.removeListener('data', this.suppressStdinOutput)
+        process.stdin.removeListener('data', Questionnaire.suppressStdinOutput)
         break
 
       default:


### PR DESCRIPTION
I noticed the following error.
Use static `Questionnaire`  instead of  `this` then the reference works.
```
events.js:64
    throw new ERR_INVALID_ARG_TYPE('listener', 'Function', listener);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "listener" argument must be of type Function. Received type undefined
    at checkListener (events.js:64:11)
    at ReadStream.removeListener (events.js:332:7)
    at ReadStream.Readable.removeListener (_stream_readable.js:897:47)
    at ReadStream.Questionnaire.suppressStdinOutput ([...]\node_modules\symfony-style-console\dist\Helper\Questionnaire.js:48:31)
    at ReadStream.emit (events.js:215:7)
    at addChunk (_stream_readable.js:308:12)
    at readableAddChunk (_stream_readable.js:289:11)
    at ReadStream.Readable.push (_stream_readable.js:223:10)
    at TTY.onStreamRead (internal/stream_base_commons.js:182:23) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```